### PR TITLE
Added option to fetch and upload old PI file to from and to S3, and added logic to update old PI file

### DIFF
--- a/process_report/tests/unit_tests.py
+++ b/process_report/tests/unit_tests.py
@@ -328,6 +328,16 @@ class TestCredit0002(TestCase):
         self.assertEqual(0, credited_projects.loc[4, "Balance"])
         self.assertEqual(800, credited_projects.loc[5, "Balance"])
 
+        updated_old_pi_answer = "PI2,2023-09\nPI3,2024-02\nPI4,2024-03\nPI1,2024-03\n"
+        with open(self.old_pi_file, "r") as f:
+            self.assertEqual(updated_old_pi_answer, f.read())
+
+    def test_apply_credit_error(self):
+        old_pi_dict = {"PI1": "2024-12"}
+        invoice_month = "2024-03"
+        with self.assertRaises(SystemExit):
+            process_report.is_old_pi(old_pi_dict, "PI1", invoice_month)
+
 
 class TestValidateBillables(TestCase):
     def setUp(self):


### PR DESCRIPTION
Partially closes #27. If the user does not provide an old_pi file, `process_report.py` will by default fetch the file from a hardcoded location in S3 storage.
Setting the `upload-to-s3` option will now upload both the processed CSV invoices and the updated PI file.

I've also renamed some functions for consistent capitalization.

I have also added a few print statements to provide the following info:
- When a new PI is encountered in an invoice
- When a future PI is found in a past invoice

It should be noted that if future PIs are encountered when processing old invoices, the invoice script will consider them new PIs for the purpose of the new PI credit, and will update the future PI's first-month date to be same as the old invoice's date.

Blocked on #23, and prerequisite to #21 