### PR TITLE
Packed invoice container into Kubernetes cronjob

### DIFF
--- a/k8/base/invoice-processing.yaml
+++ b/k8/base/invoice-processing.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: invoice-processing
+spec:
+  schedule: "0 14 1 * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: invoice-processing
+            image: ghcr.io/cci-moc/process-csv-report:latest
+            env:
+              - name: GH_NONBILLABLE_DEPLOYKEY
+                valueFrom:
+                secretKeyRef:
+                  name: gh-nonbillables
+                  key: ssh-deploykey
+              - name: S3_KEY_ID
+                valueFrom:
+                secretKeyRef:
+                  name: nerc-invoices-s3-bucket
+                  key: s3-key-id
+              - name: S3_APP_KEY
+                valueFrom:
+                secretKeyRef:
+                  name: nerc-invoices-s3-bucket
+                  key: s3-app-key
+          restartPolicy: OnFailure

--- a/k8/base/kustomization.yaml
+++ b/k8/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - invoice-processing.yaml

--- a/k8/overlay/gh-nonbillables.yaml
+++ b/k8/overlay/gh-nonbillables.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gh-nonbillables
+type: kubernetes.io/ssh-auth
+data:
+  ssh-deploykey: test

--- a/k8/overlay/kustomization.yaml
+++ b/k8/overlay/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - ../base
+  - secret-b2-old-pi.yaml
+  - secret-gh-nonbillables.yaml

--- a/k8/overlay/nerc-invoices-s3-bucket.yaml
+++ b/k8/overlay/nerc-invoices-s3-bucket.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nerc-invoices-s3-bucket
+type: Opaque
+data:
+  s3-app-key: test
+  s3-key-id: test


### PR DESCRIPTION
Blocked on #31. Closes #22. The manifests needed for the cronjob includes the cronjob, and two secret files which sets the private key for the nonbillable repo's deploykey and the s3 app_key and key_id.

The cronjob is set to run at 12:00PM (Noon) on the 1st of each month. The last commit will show what's actually included in this PR.