### PR TITLE
Upload backup of PI file after processing

### DIFF
--- a/process_report/process_report.py
+++ b/process_report/process_report.py
@@ -230,6 +230,9 @@ def main():
 
     billable_projects = remove_non_billables(merged_dataframe, pi, projects)
     billable_projects = validate_pi_names(billable_projects)
+
+    if args.upload_to_s3:
+        backup_to_s3_old_pi_file(old_pi_file)
     credited_projects = apply_credits_new_pi(billable_projects, old_pi_file)
 
     export_billables(credited_projects, args.output_file)
@@ -385,6 +388,11 @@ def fetch_s3_old_pi_file():
 def upload_to_s3_old_pi_file(old_pi_file):
     invoice_bucket = get_invoice_bucket()
     invoice_bucket.upload_file(old_pi_file, PI_S3_FILEPATH)
+
+
+def backup_to_s3_old_pi_file(old_pi_file):
+    invoice_bucket = get_invoice_bucket()
+    invoice_bucket.upload_file(old_pi_file, f"PIs/Archive/PI {get_iso8601_time()}.csv")
 
 
 def add_institution(dataframe: pandas.DataFrame):


### PR DESCRIPTION
Closes #41 `process_report.py` will now upload a backup of the PI file before it is modified during invoice processing. This is done in `fetch_s3_old_pi_file()` when the PI file is first fetched, and is noted with a comment for clarification.