### PR TITLE
Validate combined dataframe with alias file

### DIFF
--- a/process_report/tests/unit_tests.py
+++ b/process_report/tests/unit_tests.py
@@ -258,6 +258,27 @@ class TestGetInstitute(TestCase):
         )
 
 
+class TestAlias(TestCase):
+    def setUp(self):
+        self.alias_dict = {"PI1": ["PI1_1", "PI1_2"], "PI2": ["PI2_1"]}
+
+        self.data = pandas.DataFrame(
+            {
+                "Manager (PI)": ["PI1", "PI1_1", "PI1_2", "PI2_1", "PI2_1"],
+            }
+        )
+
+        self.answer = pandas.DataFrame(
+            {
+                "Manager (PI)": ["PI1", "PI1", "PI1", "PI2", "PI2"],
+            }
+        )
+
+    def test_validate_alias(self):
+        output = process_report.validate_pi_aliases(self.data, self.alias_dict)
+        self.assertTrue(self.answer.equals(output))
+
+
 class TestCredit0002(TestCase):
     def setUp(self):
         data = {


### PR DESCRIPTION
Closes #43. Added an argument `alias-file` which gives the user the choice to provide a PI alias file, else defaults to fetching the file from a hardcoded location in S3 storage ("PIs/alias.csv")

The PI file must be a csv, with the first value of each row being the canonical name for each PI every other value in each row will be the PI's known aliases.

An example:
```
PI1,PI1_1,PI1_2
PI2,PI2_1
```

Given the alias file, `validate_pi_aliases` will iterate through all projects in the combined invoice, and replace all encountered aliases with its PI's canonical name