### PR TITLE
Added NA check for empty `2nd Month Used` field

### DIFF
--- a/process_report/process_report.py
+++ b/process_report/process_report.py
@@ -471,8 +471,10 @@ def apply_credits_new_pi(dataframe, old_pi_file):
                     remaining_credit -= applied_credit
 
             credits_used = initial_credit - remaining_credit
-            if (pi_old_pi_entry[credit_used_field] != 0) and (
-                credits_used != pi_old_pi_entry[credit_used_field]
+            if (
+                not pandas.isna(pi_old_pi_entry[credit_used_field])
+                and pi_old_pi_entry[credit_used_field] != 0
+                and pi_old_pi_entry[credit_used_field] != credits_used
             ):
                 print(
                     f"Warning: PI file overwritten. PI {pi} previously used ${pi_old_pi_entry[credit_used_field]} of New PI credits, now uses ${credits_used}"


### PR DESCRIPTION
In cases where the `2nd Month Used` field for some PIs are empty in the old PI file, not having the NA check would result in an error
In the future, all PI entries should no longer have empty fields, given how this script initilizes new PI entries, so this change might not be completely nessecary. Nonetheless, it's good to check all our bases?