### PR TITLE
Loads invoice "rate" field as string to suppress scientific notation representation

### DIFF
--- a/process_report/process_report.py
+++ b/process_report/process_report.py
@@ -30,6 +30,7 @@ INSTITUTION_FIELD = "Institution"
 INSTITUTION_ID_FIELD = "Institution - Specific Code"
 SU_HOURS_FIELD = "SU Hours (GBhr or SUhr)"
 SU_TYPE_FIELD = "SU Type"
+RATE_FIELD = "Rate"
 COST_FIELD = "Cost"
 CREDIT_FIELD = "Credit"
 CREDIT_CODE_FIELD = "Credit Code"
@@ -327,7 +328,11 @@ def merge_csv(files):
     dataframes = []
     for file in files:
         dataframe = pandas.read_csv(
-            file, dtype={COST_FIELD: pandas.ArrowDtype(pyarrow.decimal128(12, 2))}
+            file,
+            dtype={
+                COST_FIELD: pandas.ArrowDtype(pyarrow.decimal128(12, 2)),
+                RATE_FIELD: str,
+            },
         )
         dataframes.append(dataframe)
 


### PR DESCRIPTION
Closes #56. Some of our rates may be have very low values, i.e 0.0000009, which may be displayed in scientific notation if read as a float by pandas.read_csv() Specifying the field type as str suppresses this behavior.