### PR TITLE
Refactored billable invoice

### DIFF
--- a/process_report/invoices/billable_invoice.py
+++ b/process_report/invoices/billable_invoice.py
@@ -16,41 +16,17 @@ logging.basicConfig(level=logging.INFO)
 
 @dataclass
 class BillableInvoice(invoice.Invoice):
+    NEW_PI_CREDIT_CODE = "0002"
+    INITIAL_CREDIT_AMOUNT = 1000
+    EXCLUDE_SU_TYPES = ["OpenShift GPUA100SXM4", "OpenStack GPUA100SXM4"]
+    PI_S3_FILEPATH = "PIs/PI.csv"
+
     nonbillable_pis: list[str]
     nonbillable_projects: list[str]
     old_pi_filepath: str
 
-    def _prepare(self):
-        self.data = self._remove_nonbillables(
-            self.data, self.nonbillable_pis, self.nonbillable_projects
-        )
-        self.data = self._validate_pi_names(self.data)
-
-    def _process(self):
-        old_pi_df = self._load_old_pis(self.old_pi_filepath)
-        self.data, updated_old_pi_df = self._apply_credits_new_pi(self.data, old_pi_df)
-        self._dump_old_pis(self.old_pi_filepath, updated_old_pi_df)
-
-    def _remove_nonbillables(
-        self,
-        data: pandas.DataFrame,
-        nonbillable_pis: list[str],
-        nonbillable_projects: list[str],
-    ):
-        return data[
-            ~data[invoice.PI_FIELD].isin(nonbillable_pis)
-            & ~data[invoice.PROJECT_FIELD].isin(nonbillable_projects)
-        ]
-
-    def _validate_pi_names(self, data: pandas.DataFrame):
-        invalid_pi_projects = data[pandas.isna(data[invoice.PI_FIELD])]
-        for i, row in invalid_pi_projects.iterrows():
-            logger.warn(
-                f"Billable project {row[invoice.PROJECT_FIELD]} has empty PI field"
-            )
-        return data[~pandas.isna(data[invoice.PI_FIELD])]
-
-    def _load_old_pis(self, old_pi_filepath) -> pandas.DataFrame:
+    @staticmethod
+    def _load_old_pis(old_pi_filepath) -> pandas.DataFrame:
         try:
             old_pi_df = pandas.read_csv(
                 old_pi_filepath,
@@ -67,30 +43,108 @@ class BillableInvoice(invoice.Invoice):
 
         return old_pi_df
 
+    @staticmethod
+    def _remove_nonbillables(
+        data: pandas.DataFrame,
+        nonbillable_pis: list[str],
+        nonbillable_projects: list[str],
+    ):
+        return data[
+            ~data[invoice.PI_FIELD].isin(nonbillable_pis)
+            & ~data[invoice.PROJECT_FIELD].isin(nonbillable_projects)
+        ]
+
+    @staticmethod
+    def _validate_pi_names(data: pandas.DataFrame):
+        invalid_pi_projects = data[pandas.isna(data[invoice.PI_FIELD])]
+        for i, row in invalid_pi_projects.iterrows():
+            logger.warn(
+                f"Billable project {row[invoice.PROJECT_FIELD]} has empty PI field"
+            )
+        return data[~pandas.isna(data[invoice.PI_FIELD])]
+
+    @staticmethod
+    def _get_pi_age(old_pi_df: pandas.DataFrame, pi, invoice_month):
+        """Returns time difference between current invoice month and PI's first invoice month
+        I.e 0 for new PIs
+        Will raise an error if the PI'a age is negative, which suggests a faulty invoice, or a program bug"""
+        first_invoice_month = old_pi_df.loc[
+            old_pi_df[invoice.PI_PI_FIELD] == pi, invoice.PI_FIRST_MONTH
+        ]
+        if first_invoice_month.empty:
+            return 0
+
+        month_diff = util.get_month_diff(invoice_month, first_invoice_month.iat[0])
+        if month_diff < 0:
+            sys.exit(
+                f"PI {pi} from {first_invoice_month} found in {invoice_month} invoice!"
+            )
+        else:
+            return month_diff
+
+    def _prepare(self):
+        self.data = self._remove_nonbillables(
+            self.data, self.nonbillable_pis, self.nonbillable_projects
+        )
+        self.data = self._validate_pi_names(self.data)
+        self.data[invoice.CREDIT_FIELD] = None
+        self.data[invoice.CREDIT_CODE_FIELD] = None
+        self.data[invoice.BALANCE_FIELD] = Decimal(0)
+        self.old_pi_df = self._load_old_pis(self.old_pi_filepath)
+
+    def _process(self):
+        self.data, self.updated_old_pi_df = self._apply_credits_new_pi(
+            self.data, self.old_pi_df
+        )
+
+    def _prepare_export(self):
+        self.updated_old_pi_df = self.updated_old_pi_df.astype(
+            {
+                invoice.PI_INITIAL_CREDITS: pandas.ArrowDtype(
+                    pyarrow.decimal128(21, 2)
+                ),
+                invoice.PI_1ST_USED: pandas.ArrowDtype(pyarrow.decimal128(21, 2)),
+                invoice.PI_2ND_USED: pandas.ArrowDtype(pyarrow.decimal128(21, 2)),
+            },
+        )
+
+    def export(self):
+        super().export()
+        self.old_pi_df.to_csv(self.old_pi_filepath, index=False)
+
+    def export_s3(self, s3_bucket):
+        super().export_s3(s3_bucket)
+        s3_bucket.upload_file(self.old_pi_filepath, self.PI_S3_FILEPATH)
+
     def _apply_credits_new_pi(
         self, data: pandas.DataFrame, old_pi_df: pandas.DataFrame
     ):
-        new_pi_credit_code = "0002"
-        INITIAL_CREDIT_AMOUNT = 1000
-        EXCLUDE_SU_TYPES = ["OpenShift GPUA100SXM4", "OpenStack GPUA100SXM4"]
+        def get_initial_credit_amount(
+            old_pi_df, invoice_month, default_initial_credit_amount
+        ):
+            first_month_processed_pis = old_pi_df[
+                old_pi_df[invoice.PI_FIRST_MONTH] == invoice_month
+            ]
+            if first_month_processed_pis[
+                invoice.PI_INITIAL_CREDITS
+            ].empty or pandas.isna(
+                new_pi_credit_amount := first_month_processed_pis[
+                    invoice.PI_INITIAL_CREDITS
+                ].iat[0]
+            ):
+                new_pi_credit_amount = default_initial_credit_amount
 
-        data[invoice.CREDIT_FIELD] = None
-        data[invoice.CREDIT_CODE_FIELD] = None
-        data[invoice.BALANCE_FIELD] = Decimal(0)
+            return new_pi_credit_amount
+
+        new_pi_credit_amount = get_initial_credit_amount(
+            old_pi_df, self.invoice_month, self.INITIAL_CREDIT_AMOUNT
+        )
+        print(f"New PI Credit set at {new_pi_credit_amount} for {self.invoice_month}")
 
         current_pi_set = set(data[invoice.PI_FIELD])
-        invoice_month = data[invoice.INVOICE_DATE_FIELD].iat[0]
-        invoice_pis = old_pi_df[old_pi_df[invoice.PI_FIRST_MONTH] == invoice_month]
-        if invoice_pis[invoice.PI_INITIAL_CREDITS].empty or pandas.isna(
-            new_pi_credit_amount := invoice_pis[invoice.PI_INITIAL_CREDITS].iat[0]
-        ):
-            new_pi_credit_amount = INITIAL_CREDIT_AMOUNT
-
-        print(f"New PI Credit set at {new_pi_credit_amount} for {invoice_month}")
-
         for pi in current_pi_set:
             pi_projects = data[data[invoice.PI_FIELD] == pi]
-            pi_age = self._get_pi_age(old_pi_df, pi, invoice_month)
+            pi_age = self._get_pi_age(old_pi_df, pi, self.invoice_month)
             pi_old_pi_entry = old_pi_df.loc[
                 old_pi_df[invoice.PI_PI_FIELD] == pi
             ].squeeze()
@@ -101,7 +155,7 @@ class BillableInvoice(invoice.Invoice):
             else:
                 if pi_age == 0:
                     if len(pi_old_pi_entry) == 0:
-                        pi_entry = [pi, invoice_month, new_pi_credit_amount, 0, 0]
+                        pi_entry = [pi, self.invoice_month, new_pi_credit_amount, 0, 0]
                         old_pi_df = pandas.concat(
                             [
                                 pandas.DataFrame([pi_entry], columns=old_pi_df.columns),
@@ -126,7 +180,7 @@ class BillableInvoice(invoice.Invoice):
                 for i, row in pi_projects.iterrows():
                     if (
                         remaining_credit == 0
-                        or row[invoice.SU_TYPE_FIELD] in EXCLUDE_SU_TYPES
+                        or row[invoice.SU_TYPE_FIELD] in self.EXCLUDE_SU_TYPES
                     ):
                         data.at[i, invoice.BALANCE_FIELD] = row[invoice.COST_FIELD]
                     else:
@@ -134,7 +188,7 @@ class BillableInvoice(invoice.Invoice):
                         applied_credit = min(project_cost, remaining_credit)
 
                         data.at[i, invoice.CREDIT_FIELD] = applied_credit
-                        data.at[i, invoice.CREDIT_CODE_FIELD] = new_pi_credit_code
+                        data.at[i, invoice.CREDIT_CODE_FIELD] = self.NEW_PI_CREDIT_CODE
                         data.at[i, invoice.BALANCE_FIELD] = (
                             row[invoice.COST_FIELD] - applied_credit
                         )
@@ -151,36 +205,4 @@ class BillableInvoice(invoice.Invoice):
                     old_pi_df[invoice.PI_PI_FIELD] == pi, credit_used_field
                 ] = credits_used
 
-        old_pi_df = old_pi_df.astype(
-            {
-                invoice.PI_INITIAL_CREDITS: pandas.ArrowDtype(
-                    pyarrow.decimal128(21, 2)
-                ),
-                invoice.PI_1ST_USED: pandas.ArrowDtype(pyarrow.decimal128(21, 2)),
-                invoice.PI_2ND_USED: pandas.ArrowDtype(pyarrow.decimal128(21, 2)),
-            },
-        )
-
         return (data, old_pi_df)
-
-    def _dump_old_pis(self, old_pi_filepath, old_pi_df: pandas.DataFrame):
-        old_pi_df.to_csv(old_pi_filepath, index=False)
-
-    def _get_pi_age(self, old_pi_df: pandas.DataFrame, pi, invoice_month):
-        """Returns time difference between current invoice month and PI's first invoice month
-        I.e 0 for new PIs
-
-        Will raise an error if the PI'a age is negative, which suggests a faulty invoice, or a program bug"""
-        first_invoice_month = old_pi_df.loc[
-            old_pi_df[invoice.PI_PI_FIELD] == pi, invoice.PI_FIRST_MONTH
-        ]
-        if first_invoice_month.empty:
-            return 0
-
-        month_diff = util.get_month_diff(invoice_month, first_invoice_month.iat[0])
-        if month_diff < 0:
-            sys.exit(
-                f"PI {pi} from {first_invoice_month} found in {invoice_month} invoice!"
-            )
-        else:
-            return month_diff

--- a/process_report/invoices/billable_invoice.py
+++ b/process_report/invoices/billable_invoice.py
@@ -1,0 +1,186 @@
+from dataclasses import dataclass
+from decimal import Decimal
+import logging
+import sys
+
+import pandas
+import pyarrow
+
+import process_report.invoices.invoice as invoice
+import process_report.util as util
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+@dataclass
+class BillableInvoice(invoice.Invoice):
+    nonbillable_pis: list[str]
+    nonbillable_projects: list[str]
+    old_pi_filepath: str
+
+    def _prepare(self):
+        self.data = self._remove_nonbillables(
+            self.data, self.nonbillable_pis, self.nonbillable_projects
+        )
+        self.data = self._validate_pi_names(self.data)
+
+    def _process(self):
+        old_pi_df = self._load_old_pis(self.old_pi_filepath)
+        self.data, updated_old_pi_df = self._apply_credits_new_pi(self.data, old_pi_df)
+        self._dump_old_pis(self.old_pi_filepath, updated_old_pi_df)
+
+    def _remove_nonbillables(
+        self,
+        data: pandas.DataFrame,
+        nonbillable_pis: list[str],
+        nonbillable_projects: list[str],
+    ):
+        return data[
+            ~data[invoice.PI_FIELD].isin(nonbillable_pis)
+            & ~data[invoice.PROJECT_FIELD].isin(nonbillable_projects)
+        ]
+
+    def _validate_pi_names(self, data: pandas.DataFrame):
+        invalid_pi_projects = data[pandas.isna(data[invoice.PI_FIELD])]
+        for i, row in invalid_pi_projects.iterrows():
+            logger.warn(
+                f"Billable project {row[invoice.PROJECT_FIELD]} has empty PI field"
+            )
+        return data[~pandas.isna(data[invoice.PI_FIELD])]
+
+    def _load_old_pis(self, old_pi_filepath) -> pandas.DataFrame:
+        try:
+            old_pi_df = pandas.read_csv(
+                old_pi_filepath,
+                dtype={
+                    invoice.PI_INITIAL_CREDITS: pandas.ArrowDtype(
+                        pyarrow.decimal128(21, 2)
+                    ),
+                    invoice.PI_1ST_USED: pandas.ArrowDtype(pyarrow.decimal128(21, 2)),
+                    invoice.PI_2ND_USED: pandas.ArrowDtype(pyarrow.decimal128(21, 2)),
+                },
+            )
+        except FileNotFoundError:
+            sys.exit("Applying credit 0002 failed. Old PI file does not exist")
+
+        return old_pi_df
+
+    def _apply_credits_new_pi(
+        self, data: pandas.DataFrame, old_pi_df: pandas.DataFrame
+    ):
+        new_pi_credit_code = "0002"
+        INITIAL_CREDIT_AMOUNT = 1000
+        EXCLUDE_SU_TYPES = ["OpenShift GPUA100SXM4", "OpenStack GPUA100SXM4"]
+
+        data[invoice.CREDIT_FIELD] = None
+        data[invoice.CREDIT_CODE_FIELD] = None
+        data[invoice.BALANCE_FIELD] = Decimal(0)
+
+        current_pi_set = set(data[invoice.PI_FIELD])
+        invoice_month = data[invoice.INVOICE_DATE_FIELD].iat[0]
+        invoice_pis = old_pi_df[old_pi_df[invoice.PI_FIRST_MONTH] == invoice_month]
+        if invoice_pis[invoice.PI_INITIAL_CREDITS].empty or pandas.isna(
+            new_pi_credit_amount := invoice_pis[invoice.PI_INITIAL_CREDITS].iat[0]
+        ):
+            new_pi_credit_amount = INITIAL_CREDIT_AMOUNT
+
+        print(f"New PI Credit set at {new_pi_credit_amount} for {invoice_month}")
+
+        for pi in current_pi_set:
+            pi_projects = data[data[invoice.PI_FIELD] == pi]
+            pi_age = self._get_pi_age(old_pi_df, pi, invoice_month)
+            pi_old_pi_entry = old_pi_df.loc[
+                old_pi_df[invoice.PI_PI_FIELD] == pi
+            ].squeeze()
+
+            if pi_age > 1:
+                for i, row in pi_projects.iterrows():
+                    data.at[i, invoice.BALANCE_FIELD] = row[invoice.COST_FIELD]
+            else:
+                if pi_age == 0:
+                    if len(pi_old_pi_entry) == 0:
+                        pi_entry = [pi, invoice_month, new_pi_credit_amount, 0, 0]
+                        old_pi_df = pandas.concat(
+                            [
+                                pandas.DataFrame([pi_entry], columns=old_pi_df.columns),
+                                old_pi_df,
+                            ],
+                            ignore_index=True,
+                        )
+                        pi_old_pi_entry = old_pi_df.loc[
+                            old_pi_df[invoice.PI_PI_FIELD] == pi
+                        ].squeeze()
+
+                    remaining_credit = new_pi_credit_amount
+                    credit_used_field = invoice.PI_1ST_USED
+                elif pi_age == 1:
+                    remaining_credit = (
+                        pi_old_pi_entry[invoice.PI_INITIAL_CREDITS]
+                        - pi_old_pi_entry[invoice.PI_1ST_USED]
+                    )
+                    credit_used_field = invoice.PI_2ND_USED
+
+                initial_credit = remaining_credit
+                for i, row in pi_projects.iterrows():
+                    if (
+                        remaining_credit == 0
+                        or row[invoice.SU_TYPE_FIELD] in EXCLUDE_SU_TYPES
+                    ):
+                        data.at[i, invoice.BALANCE_FIELD] = row[invoice.COST_FIELD]
+                    else:
+                        project_cost = row[invoice.COST_FIELD]
+                        applied_credit = min(project_cost, remaining_credit)
+
+                        data.at[i, invoice.CREDIT_FIELD] = applied_credit
+                        data.at[i, invoice.CREDIT_CODE_FIELD] = new_pi_credit_code
+                        data.at[i, invoice.BALANCE_FIELD] = (
+                            row[invoice.COST_FIELD] - applied_credit
+                        )
+                        remaining_credit -= applied_credit
+
+                credits_used = initial_credit - remaining_credit
+                if (pi_old_pi_entry[credit_used_field] != 0) and (
+                    credits_used != pi_old_pi_entry[credit_used_field]
+                ):
+                    print(
+                        f"Warning: PI file overwritten. PI {pi} previously used ${pi_old_pi_entry[credit_used_field]} of New PI credits, now uses ${credits_used}"
+                    )
+                old_pi_df.loc[
+                    old_pi_df[invoice.PI_PI_FIELD] == pi, credit_used_field
+                ] = credits_used
+
+        old_pi_df = old_pi_df.astype(
+            {
+                invoice.PI_INITIAL_CREDITS: pandas.ArrowDtype(
+                    pyarrow.decimal128(21, 2)
+                ),
+                invoice.PI_1ST_USED: pandas.ArrowDtype(pyarrow.decimal128(21, 2)),
+                invoice.PI_2ND_USED: pandas.ArrowDtype(pyarrow.decimal128(21, 2)),
+            },
+        )
+
+        return (data, old_pi_df)
+
+    def _dump_old_pis(self, old_pi_filepath, old_pi_df: pandas.DataFrame):
+        old_pi_df.to_csv(old_pi_filepath, index=False)
+
+    def _get_pi_age(self, old_pi_df: pandas.DataFrame, pi, invoice_month):
+        """Returns time difference between current invoice month and PI's first invoice month
+        I.e 0 for new PIs
+
+        Will raise an error if the PI'a age is negative, which suggests a faulty invoice, or a program bug"""
+        first_invoice_month = old_pi_df.loc[
+            old_pi_df[invoice.PI_PI_FIELD] == pi, invoice.PI_FIRST_MONTH
+        ]
+        if first_invoice_month.empty:
+            return 0
+
+        month_diff = util.get_month_diff(invoice_month, first_invoice_month.iat[0])
+        if month_diff < 0:
+            sys.exit(
+                f"PI {pi} from {first_invoice_month} found in {invoice_month} invoice!"
+            )
+        else:
+            return month_diff

--- a/process_report/invoices/invoice.py
+++ b/process_report/invoices/invoice.py
@@ -4,6 +4,14 @@ import pandas
 import process_report.util as util
 
 
+### PI file field names
+PI_PI_FIELD = "PI"
+PI_FIRST_MONTH = "First Invoice Month"
+PI_INITIAL_CREDITS = "Initial Credits"
+PI_1ST_USED = "1st Month Used"
+PI_2ND_USED = "2nd Month Used"
+###
+
 ### Invoice field names
 INVOICE_DATE_FIELD = "Invoice Month"
 PROJECT_FIELD = "Project - Allocation"

--- a/process_report/process_report.py
+++ b/process_report/process_report.py
@@ -154,7 +154,7 @@ def main():
     parser.add_argument(
         "--output-file",
         required=False,
-        default="filtered_output",
+        default="billable",
         help="Name of output file",
     )
     parser.add_argument(
@@ -282,7 +282,6 @@ def main():
 
         upload_to_s3(invoice_list, invoice_month)
         upload_to_s3_HU_BU(args.HU_BU_invoice_file, invoice_month)
-        upload_to_s3_old_pi_file(old_pi_file)
 
 
 def fetch_s3_invoices(invoice_month):
@@ -363,11 +362,6 @@ def fetch_s3_old_pi_file():
     invoice_bucket = get_invoice_bucket()
     invoice_bucket.download_file(PI_S3_FILEPATH, local_name)
     return local_name
-
-
-def upload_to_s3_old_pi_file(old_pi_file):
-    invoice_bucket = get_invoice_bucket()
-    invoice_bucket.upload_file(old_pi_file, PI_S3_FILEPATH)
 
 
 def backup_to_s3_old_pi_file(old_pi_file):

--- a/process_report/tests/util.py
+++ b/process_report/tests/util.py
@@ -1,0 +1,21 @@
+import pandas
+
+from process_report.invoices import billable_invoice
+
+
+def new_billable_invoice(
+    name="",
+    invoice_month="0000-00",
+    data=pandas.DataFrame(),
+    nonbillable_pis=[],
+    nonbillable_projects=[],
+    old_pi_filepath="",
+):
+    return billable_invoice.BillableInvoice(
+        name,
+        invoice_month,
+        data,
+        nonbillable_pis,
+        nonbillable_projects,
+        old_pi_filepath,
+    )

--- a/process_report/util.py
+++ b/process_report/util.py
@@ -33,3 +33,10 @@ def compare_invoice_month(month_1, month_2):
     dt1 = datetime.datetime.strptime(month_1, "%Y-%m")
     dt2 = datetime.datetime.strptime(month_2, "%Y-%m")
     return dt1 > dt2
+
+
+def get_month_diff(month_1, month_2):
+    """Returns a positive integer if month_1 is ahead in time of month_2"""
+    dt1 = datetime.datetime.strptime(month_1, "%Y-%m")
+    dt2 = datetime.datetime.strptime(month_2, "%Y-%m")
+    return (dt1.year - dt2.year) * 12 + (dt1.month - dt2.month)


### PR DESCRIPTION
Closes #64, I have refactored the billable invoice. I'll explain in more detail below, and have also have a question that I would like the professionals' opinions on.

For some context, the billable invoice performs 2 preparation steps (removing nonbillables and validating PI names) and 3 distinct steps during processing (loading the old PI file, applying the new PI credit, and then writing back the old PI file). I decided to split these steps into their own functions, and to store those functions in `util.py`, instead of making them private functions in the`BillableInvoice` class.

As for the test cases, I created a new test class for the billable invoice. Note that this new test case uses randomly generated values, instead of a hardcoded dataframe. I figured this would be more robust?

While writing the test case, l also had a few design questions I wanted to ask...

Considering how unsightly some of the test cases are, especially for the [New PI credit](https://github.com/CCI-MOC/process_csv_report/blob/040055787597f03ec5ed180e6fbd376d8fd8bdcb/process_report/tests/unit_tests.py#L298), I was trying to think of ways to make the test case more organized and easier to follow. One of them was to create small test functions that would only test for one specific scenario (i.e a case for new PI, 1-month PI, overwritten entry, etc...), and to make a generator function that would that randomly generate the invoice and old-pi file (along with the expected output after they are processed) for a PI. I'm follow your opinions on whether randomized test data, instead of hardcoded data, would be better.