### PR TITLE
Fixed the two new domains

### DIFF
--- a/process_report/institute_map.json
+++ b/process_report/institute_map.json
@@ -24,6 +24,6 @@
     "kmdalton"              : "Harvard University",
     "mzink"                 : "University of Massachusetts Amherst",
     "francesco.pontiggia"   : "Harvard University",
-    "chemistry.harvard"     : "Harvard University",
-    "dartmouth"             : "Dartmouth College"
+    "chemistry.harvard.edu"     : "Harvard University",
+    "dartmouth.edu"             : "Dartmouth College"
 }


### PR DESCRIPTION
The two new domains added were not written properly, such that PIs with the email domains dartmouth.edu or chemistry.harvard.edu would never be matched