### PR TITLE
Refactored the HU-BU invoice

### DIFF
--- a/process_report/invoices/hu_bu_invoice.py
+++ b/process_report/invoices/hu_bu_invoice.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+
+import process_report.invoices.invoice as invoice
+import process_report.util as util
+
+
+@dataclass
+class HUBUInvoice(invoice.Invoice):
+    @property
+    def output_s3_key(self) -> str:
+        return (
+            f"Invoices/{self.invoice_month}/NERC-{self.invoice_month}-Total-Invoice.csv"
+        )
+
+    @property
+    def output_s3_archive_key(self):
+        return f"Invoices/{self.invoice_month}/Archive/NERC-{self.invoice_month}-Total-Invoice {util.get_iso8601_time()}.csv"
+
+    def _prepare_export(self):
+        self.data = self.data[
+            (self.data[invoice.INSTITUTION_FIELD] == "Harvard University")
+            | (self.data[invoice.INSTITUTION_FIELD] == "Boston University")
+        ].copy()


### PR DESCRIPTION
Closes #68. Not necessarily dependent on #61, but is part of the overall refactor process. Aside from the addition of `hu_bu_invoice.py`, I decided to cache the results of `get_invoice_bucket()` using [functools](https://docs.python.org/dev/library/functools.html#functools.lru_cache)

While refactoring, I noticed that I didn't add code to upload the BU Internal invoice to S3, and also forgot to remove some [functions](https://github.com/CCI-MOC/process_csv_report/blob/abe2deb8da7bafb1682018da6fef090937caac2c/process_report/process_report.py#L49-L59) from `process_report.py` that have been [moved](https://github.com/CCI-MOC/process_csv_report/blob/abe2deb8da7bafb1682018da6fef090937caac2c/process_report/util.py#L10-L17) to `utils.py`. @naved001 @knikolla Should these be part of a separate commit or issue?