### PR TITLE
Refactored PI-specific invoices

### DIFF
--- a/process_report/invoices/pi_specific_invoice.py
+++ b/process_report/invoices/pi_specific_invoice.py
@@ -1,0 +1,43 @@
+import os
+from dataclasses import dataclass
+
+import pandas
+
+import process_report.invoices.invoice as invoice
+import process_report.util as util
+
+
+@dataclass
+class PIInvoice(invoice.Invoice):
+    def _prepare(self):
+        self.pi_list = self.data[invoice.PI_FIELD].unique()
+
+    def export(self):
+        def _export_pi_invoice(pi):
+            if pandas.isna(pi):
+                return
+            pi_projects = self.data[self.data[invoice.PI_FIELD] == pi]
+            pi_instituition = pi_projects[invoice.INSTITUTION_FIELD].iat[0]
+            pi_projects.to_csv(
+                f"{self.name}/{pi_instituition}_{pi} {self.invoice_month}.csv"
+            )
+
+        if not os.path.exists(
+            self.name
+        ):  # self.name is name of folder storing invoices
+            os.mkdir(self.name)
+
+        for pi in self.pi_list:
+            _export_pi_invoice(pi)
+
+    def export_s3(self, s3_bucket):
+        def _export_s3_pi_invoice(pi_invoice):
+            pi_invoice_path = os.path.join(self.name, pi_invoice)
+            striped_invoice_path = os.path.splitext(pi_invoice_path)[0]
+            output_s3_path = f"Invoices/{self.invoice_month}/{striped_invoice_path}.csv"
+            output_s3_archive_path = f"Invoices/{self.invoice_month}/Archive/{striped_invoice_path} {util.get_iso8601_time()}.csv"
+            s3_bucket.upload_file(pi_invoice_path, output_s3_path)
+            s3_bucket.upload_file(pi_invoice_path, output_s3_archive_path)
+
+        for pi_invoice in os.listdir(self.name):
+            _export_s3_pi_invoice(pi_invoice)

--- a/process_report/tests/util.py
+++ b/process_report/tests/util.py
@@ -1,6 +1,19 @@
 import pandas
 
-from process_report.invoices import billable_invoice, bu_internal_invoice
+from process_report.invoices import (
+    invoice,
+    billable_invoice,
+    bu_internal_invoice,
+    pi_specific_invoice,
+)
+
+
+def new_base_invoice(
+    name="",
+    invoice_month="0000-00",
+    data=pandas.DataFrame(),
+):
+    return invoice.Invoice(name, invoice_month, data)
 
 
 def new_billable_invoice(
@@ -26,4 +39,16 @@ def new_bu_internal_invoice(
 ):
     return bu_internal_invoice.BUInternalInvoice(
         name, invoice_month, data, subsidy_amount
+    )
+
+
+def new_pi_specific_invoice(
+    name="",
+    invoice_month="0000-00",
+    data=pandas.DataFrame(),
+):
+    return pi_specific_invoice.PIInvoice(
+        name,
+        invoice_month,
+        data,
     )


### PR DESCRIPTION
Closes #69. The PI-specific is now implemented in the `PIInvoice` class. This class takes in the entire billable invoice and will export the PI invoices to local storage and S3. Because of its unique export file paths, it overrides the `export()`

Note that to follow the file path has changed slightly, from:
`f"{self.name}/{pi_instituition}_{pi}_{self.invoice_month}.csv"`
to...
`f"{self.name}/{pi_instituition}_{pi} {self.invoice_month}.csv"`

Note that replacement of the "_" to " ". I do this to be more consistent with the filename pattern for the other invoices.
Aside from that, I've also removed `upload_to_s3()` and its corresponding unit test, since it is no longer needed (after this PR, and certainly after all the refactor PRs are merged). @knikolla @naved001 Should I add a test for each invoice to see if they are exporting to desired S3 paths?