### PR TITLE
Allow limiting New-PI credit to partner institutions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ RUN pip install -r requirements.txt
 
 COPY tools/ tools/
 COPY process_report/process_report.py process_report/
-COPY process_report/institute_map.json process_report/
+COPY process_report/institute_list.yaml process_report/
 
 CMD ["tools/clone_nonbillables_and_process_invoice.sh"]

--- a/process_report/institute_list.yaml
+++ b/process_report/institute_list.yaml
@@ -1,0 +1,74 @@
+-   display_name: Northeastern University
+    domains:
+    - northeastern.edu
+-   display_name: Boston University
+    domains:
+    - bu.edu
+    - robbaron
+-   display_name: Bentley
+    domains:
+    - bentley.edu
+-   display_name: University of Rhode Island
+    domains:
+    - uri.edu
+-   display_name: Red Hat
+    domains:
+    - redhat.com
+-   display_name: Boston Childrens Hospital
+    domains:
+    - childrens.harvard.edu
+    - rudolph
+-   display_name: McLean Hospital
+    domains:
+    - mclean.harvard.edu
+-   display_name: Massachusetts Eye & Ear
+    domains:
+    - meei.harvard.edu
+-   display_name: Dana-Farber Cancer Institute
+    domains:
+    - dfci.harvard.edu
+-   display_name: Brigham and Women's Hospital
+    domains:
+    - bwh.harvard.edu
+-   display_name: Beth Israel Deaconess Medical Center
+    domains:
+    - bidmc.harvard.edu
+-   display_name: Harvard University
+    domains:
+    - harvard.edu
+    - mmsh
+    - kmdalton
+    - francesco.pontiggia
+    - chemistry.harvard.edu
+-   display_name: Worcester Polytechnic Institute
+    domains:
+    - wpi.edu
+-   display_name: Massachusetts Institute of Technology
+    domains:
+    - mit.edu
+-   display_name: University of Massachusetts Amherst
+    domains:
+    - umass.edu
+    - gstuart
+    - mzink
+-   display_name: University of Massachusetts Lowell
+    domains:
+    - uml.edu
+-   display_name: Code For Boston
+    domains:
+    - codeforboston.org
+-   display_name: Yale University
+    domains:
+    - yale.edu
+-   display_name: Dartmouth College
+    domains:
+    - dartmouth.edu
+-   display_name: Photrek
+    domains:
+    - photrek.io
+-   display_name: Positron Networks
+    domains:
+    - positronnetworks.com
+-   display_name: Next Generation Justice
+    domains:
+    - nextgenjustice.llc

--- a/process_report/institute_list.yaml
+++ b/process_report/institute_list.yaml
@@ -4,7 +4,6 @@
 -   display_name: Boston University
     domains:
     - bu.edu
-    - robbaron
 -   display_name: Bentley
     domains:
     - bentley.edu
@@ -17,7 +16,6 @@
 -   display_name: Boston Childrens Hospital
     domains:
     - childrens.harvard.edu
-    - rudolph
 -   display_name: McLean Hospital
     domains:
     - mclean.harvard.edu
@@ -36,9 +34,6 @@
 -   display_name: Harvard University
     domains:
     - harvard.edu
-    - mmsh
-    - kmdalton
-    - francesco.pontiggia
     - chemistry.harvard.edu
 -   display_name: Worcester Polytechnic Institute
     domains:
@@ -49,8 +44,6 @@
 -   display_name: University of Massachusetts Amherst
     domains:
     - umass.edu
-    - gstuart
-    - mzink
 -   display_name: University of Massachusetts Lowell
     domains:
     - uml.edu

--- a/process_report/process_report.py
+++ b/process_report/process_report.py
@@ -4,6 +4,7 @@ import datetime
 
 import pandas
 import pyarrow
+from nerc_rates import load_from_url
 
 from process_report import util
 from process_report.invoices import (
@@ -215,6 +216,7 @@ def main():
     if args.upload_to_s3:
         backup_to_s3_old_pi_file(old_pi_file)
 
+    rates_info = load_from_url()
     billable_inv = billable_invoice.BillableInvoice(
         name=args.output_file,
         invoice_month=invoice_month,
@@ -222,6 +224,9 @@ def main():
         nonbillable_pis=pi,
         nonbillable_projects=projects,
         old_pi_filepath=old_pi_file,
+        limit_new_pi_credit_to_partners=rates_info.get_value_at(
+            "Limit New PI Credit to MGHPCC Partners", invoice_month
+        ),
     )
 
     util.process_and_export_invoices(

--- a/process_report/process_report.py
+++ b/process_report/process_report.py
@@ -2,11 +2,10 @@ import argparse
 import sys
 import datetime
 
-import json
 import pandas
 import pyarrow
 
-from process_report.util import get_invoice_bucket, process_and_export_invoices
+from process_report import util
 from process_report.invoices import (
     lenovo_invoice,
     nonbillable_invoice,
@@ -49,26 +48,6 @@ PI_S3_FILEPATH = "PIs/PI.csv"
 
 
 ALIAS_S3_FILEPATH = "PIs/alias.csv"
-
-
-def get_institution_from_pi(institute_map, pi_uname):
-    institution_domain = pi_uname.split("@")[-1]
-    for i in range(institution_domain.count(".") + 1):
-        if institution_name := institute_map.get(institution_domain, ""):
-            break
-        institution_domain = institution_domain[institution_domain.find(".") + 1 :]
-
-    if institution_name == "":
-        print(f"Warning: PI name {pi_uname} does not match any institution!")
-
-    return institution_name
-
-
-def load_institute_map() -> dict:
-    with open("process_report/institute_map.json", "r") as f:
-        institute_map = json.load(f)
-
-    return institute_map
 
 
 def load_alias(alias_file):
@@ -245,7 +224,7 @@ def main():
         old_pi_filepath=old_pi_file,
     )
 
-    process_and_export_invoices(
+    util.process_and_export_invoices(
         [lenovo_inv, nonbillable_inv, billable_inv], args.upload_to_s3
     )
 
@@ -266,7 +245,7 @@ def main():
         name=args.output_folder, invoice_month=invoice_month, data=billable_inv.data
     )
 
-    process_and_export_invoices(
+    util.process_and_export_invoices(
         [nerc_total_inv, bu_internal_inv, pi_inv], args.upload_to_s3
     )
 
@@ -274,7 +253,7 @@ def main():
 def fetch_s3_invoices(invoice_month):
     """Fetches usage invoices from S3 given invoice month"""
     s3_invoice_list = list()
-    invoice_bucket = get_invoice_bucket()
+    invoice_bucket = util.get_invoice_bucket()
     for obj in invoice_bucket.objects.filter(
         Prefix=f"Invoices/{invoice_month}/Service Invoices/"
     ):
@@ -339,20 +318,20 @@ def validate_pi_aliases(dataframe: pandas.DataFrame, alias_dict: dict):
 
 def fetch_s3_alias_file():
     local_name = "alias.csv"
-    invoice_bucket = get_invoice_bucket()
+    invoice_bucket = util.get_invoice_bucket()
     invoice_bucket.download_file(ALIAS_S3_FILEPATH, local_name)
     return local_name
 
 
 def fetch_s3_old_pi_file():
     local_name = "PI.csv"
-    invoice_bucket = get_invoice_bucket()
+    invoice_bucket = util.get_invoice_bucket()
     invoice_bucket.download_file(PI_S3_FILEPATH, local_name)
     return local_name
 
 
 def backup_to_s3_old_pi_file(old_pi_file):
-    invoice_bucket = get_invoice_bucket()
+    invoice_bucket = util.get_invoice_bucket()
     invoice_bucket.upload_file(old_pi_file, f"PIs/Archive/PI {get_iso8601_time()}.csv")
 
 
@@ -368,14 +347,15 @@ def add_institution(dataframe: pandas.DataFrame):
 
     The list of mappings are defined in `institute_map.json`.
     """
-    institute_map = load_institute_map()
+    institute_list = util.load_institute_list()
+    institute_map = util.get_institute_mapping(institute_list)
     dataframe = dataframe.astype({INSTITUTION_FIELD: "str"})
     for i, row in dataframe.iterrows():
         pi_name = row[PI_FIELD]
         if pandas.isna(pi_name):
             print(f"Project {row[PROJECT_FIELD]} has no PI")
         else:
-            dataframe.at[i, INSTITUTION_FIELD] = get_institution_from_pi(
+            dataframe.at[i, INSTITUTION_FIELD] = util.get_institution_from_pi(
                 institute_map, pi_name
             )
 

--- a/process_report/tests/unit_tests.py
+++ b/process_report/tests/unit_tests.py
@@ -250,7 +250,7 @@ class TestGetInstitute(TestCase):
 
         for pi_email, answer in answers.items():
             self.assertEqual(
-                process_report.get_institution_from_pi(institute_map, pi_email), answer
+                util.get_institution_from_pi(institute_map, pi_email), answer
             )
 
 
@@ -789,7 +789,7 @@ class TestExportLenovo(TestCase):
 
 
 class TestUploadToS3(TestCase):
-    @mock.patch("process_report.process_report.get_invoice_bucket")
+    @mock.patch("process_report.util.get_invoice_bucket")
     @mock.patch("process_report.util.get_iso8601_time")
     def test_upload_to_s3(self, mock_get_time, mock_get_bucket):
         mock_bucket = mock.MagicMock()

--- a/process_report/tests/util.py
+++ b/process_report/tests/util.py
@@ -23,6 +23,7 @@ def new_billable_invoice(
     nonbillable_pis=[],
     nonbillable_projects=[],
     old_pi_filepath="",
+    limit_new_pi_credit_to_partners=False,
 ):
     return billable_invoice.BillableInvoice(
         name,
@@ -31,6 +32,7 @@ def new_billable_invoice(
         nonbillable_pis,
         nonbillable_projects,
         old_pi_filepath,
+        limit_new_pi_credit_to_partners,
     )
 
 

--- a/process_report/util.py
+++ b/process_report/util.py
@@ -44,7 +44,7 @@ def get_institution_from_pi(institute_map, pi_uname):
         institution_domain = institution_domain[institution_domain.find(".") + 1 :]
 
     if institution_name == "":
-        print(f"Warning: PI name {pi_uname} does not match any institution!")
+        logger.warn(f"PI name {pi_uname} does not match any institution!")
 
     return institution_name
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+git+https://github.com/CCI-MOC/nerc-rates@74eb4a7#egg=nerc_rates
 pandas
 pyarrow
 boto3


### PR DESCRIPTION
Closes #94, `process_report.py` will now use `nerc_rates` to determine if the New-PI credit is limited to institutions that are MGHPCC partners for the given invoice month.

The script determines whether an institution's MGHPCC partnership is active by first seeing if the `mghpcc_partnership_start_date` field is set in `institute_list.yaml`, then checks if the start date is within or before the invoice month.

@joachimweyl To mark an institution as an MGHPCC partner, you will need to set the field `mghpcc_partnership_start_date` in `institute_list.yaml` to the start date of the partnership in YYYY-MM format.

I.e for Boston University, their current entry looks like this:
```
-   display_name: Boston University
    domains:
    - bu.edu
    - robbaron
```

To mark them as a partner, change their entry like so:
```
-   display_name: Boston University
    domains:
    - bu.edu
    - robbaron
    mghpcc_partnership_start_date: "2024-10"
```