### PR TITLE
Correctly convert nerc-rates value to boolean

### DIFF
--- a/process_report/process_report.py
+++ b/process_report/process_report.py
@@ -53,7 +53,6 @@ BALANCE_FIELD = "Balance"
 
 PI_S3_FILEPATH = "PIs/PI.csv"
 
-
 ALIAS_S3_FILEPATH = "PIs/alias.csv"
 
 
@@ -236,8 +235,11 @@ def main():
         invoice_month,
         data=validate_billable_pi_proc.data,
         old_pi_filepath=old_pi_file,
-        limit_new_pi_credit_to_partners=rates_info.get_value_at(
-            "Limit New PI Credit to MGHPCC Partners", invoice_month
+        limit_new_pi_credit_to_partners=(
+            rates_info.get_value_at(
+                "Limit New PI Credit to MGHPCC Partners", invoice_month
+            )
+            == "True",
         ),
     )
     new_pi_credit_proc.process()


### PR DESCRIPTION
Closes #130

All values in nerc-rates are of type string and
need to be correctly interpreted by the caller.

Value for Limit New PI Credit to MGHPCC Partners is of type string and value "True" and is being passed as such to a method expecting a boolean.

This change add a comparison with the string "True" to perform the conversion.