### PR TITLE
Fixed reference to `self.export_data` in pi-specific invoice

### DIFF
--- a/process_report/invoices/pi_specific_invoice.py
+++ b/process_report/invoices/pi_specific_invoice.py
@@ -43,13 +43,13 @@ class PIInvoice(invoice.Invoice):
         def _export_pi_invoice(pi):
             if pandas.isna(pi):
                 return
-            pi_projects = export_data[export_data[invoice.PI_FIELD] == pi]
+            pi_projects = self.export_data[self.export_data[invoice.PI_FIELD] == pi]
             pi_instituition = pi_projects[invoice.INSTITUTION_FIELD].iat[0]
             pi_projects.to_csv(
                 f"{self.name}/{pi_instituition}_{pi} {self.invoice_month}.csv"
             )
 
-        export_data = self._filter_columns()
+        self._filter_columns()
         if not os.path.exists(
             self.name
         ):  # self.name is name of folder storing invoices


### PR DESCRIPTION
While test-running my code, I discovered that I forgot to change a part in `pi_specific_invoice.py` that had become deprecated after merging #119. Before this PR, `self.export_data` would be assigned to a None value, instead of the actual export data.

My apologies. I should have tested my code more thoroughly myself.